### PR TITLE
Quick patch to use xtrx_open_string() instead of the removed xtrx_open_list().

### DIFF
--- a/lib/xtrx/xtrx_obj.cc
+++ b/lib/xtrx/xtrx_obj.cc
@@ -68,7 +68,7 @@ xtrx_obj::xtrx_obj(const std::string &path, unsigned loglevel, bool lmsreset)
   unsigned xtrxflag = (loglevel & XTRX_O_LOGLVL_MASK) | ((lmsreset) ? XTRX_O_RESET : 0);
   std::cerr << "xtrx_obj::xtrx_obj = " << xtrxflag << std::endl;
 
-  int res = xtrx_open_list(path.c_str(), NULL, &_obj);
+  int res = xtrx_open_string(path.c_str(), &_obj);
   if (res < 0) {
     std::stringstream message;
     message << "Couldn't open "  ": Error: " << -res;


### PR DESCRIPTION
A change to libxtrx removes the `xtrx_open_list` function, breaking this library.
This patch replaces that call with the new `xtrx_open_string`.